### PR TITLE
Better .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,70 @@
-/target/
+## Mac ##
+.DS_Store
+
+
+### Eclipse ###
+
+target/
+bin/
+.classpath
+.project
+.metadata
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+## EXTERNAL TOOLS ##
+
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+# Annotation Processing
+.apt_generated
+
+.sts4-cache/


### PR DESCRIPTION
Adds a comprehensive .gitignore I commonly use to ensure that, no matter who forks the repository, settings files are ignored.

- Ignore Eclipse project settings
- Ignore Mac .DS_Store
- Ignore other external tool settings

Ignoring external settings helps others easily import a project and start working on it using their own preferred settings.